### PR TITLE
Reduce exclamation marks in welcome heading

### DIFF
--- a/LibraryManagementSystem/Views/Home/Index.cshtml
+++ b/LibraryManagementSystem/Views/Home/Index.cshtml
@@ -3,6 +3,6 @@
 }
 
 <div class="text-center">
-    <h1 class="display-4">Welcome!!!!!!!!!</h1>
+    <h1 class="display-4">Welcome!!!!!</h1>
     <p>Learn about our library page <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Cores "343"</a>.</p>
 </div>


### PR DESCRIPTION
The "Welcome" heading on the home page now uses five exclamation marks instead of nine for a cleaner appearance.